### PR TITLE
chore(ci): add release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,23 @@
+name: 🚀 Release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install tools
+        run: pip install python-semantic-release commitizen
+      - name: Publish release
+        run: semantic-release publish


### PR DESCRIPTION
Este commit cria o pipeline de release automático:

- Arquivo: `.github/workflows/ci-release.yml`
- Gatilho: `push` na branch `main`
- Passos:
  1. Faz checkout do código
  2. Configura Python 3.x
  3. Instala `python-semantic-release` e `commitizen`
  4. Roda `semantic-release publish` usando `GITHUB_TOKEN`

- Objetivo: versionamento SemVer, geração de CHANGELOG.md e criação de Release no GitHub sem intervenção manual.